### PR TITLE
Add more complete stream download example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,13 +175,17 @@ fetch('https://httpbin.org/status/400')
 ## Advanced Usage
 
 #### Streams
-The "Node.js way" is to use streams when possible:
+The "Node.js way" is to use streams when possible. You can pipe `res.body` to another stream. This example uses [stream.pipeline](https://nodejs.org/api/stream.html#stream_stream_pipeline_streams_callback) (requires node 10+) to attach stream error handlers and wait for the download to complete.
 
 ```js
+const util = require('util');
+const fs = require('fs');
+const streamPipeline = util.promisify(require('stream').pipeline);
+
 fetch('https://assets-cdn.github.com/images/modules/logos_page/Octocat.png')
     .then(res => {
-        const dest = fs.createWriteStream('./octocat.png');
-        res.body.pipe(dest);
+        if (!res.ok) throw new Error(`unexpected response ${res.statusText}`);
+        return streamPipeline(res.body, fs.createWriteStream('./octocat.png'));
     });
 ```
 


### PR DESCRIPTION
This PR is based on https://github.com/bitinn/node-fetch/issues/375#issuecomment-495953540 and https://github.com/bitinn/node-fetch/issues/375#issuecomment-496010966, which suggested opening an issue. I thought it might be easier to just open this PR.

The current stream example is correct but leaves out error handling and doesn't wait for the download to complete, which I think most users would probably want to do. There is a new helper function in node 10+, [stream.pipeline](https://nodejs.org/api/stream.html#stream_stream_pipeline_streams_callback) that makes it not too much harder to do both.

I've adjusted the async/await example in https://github.com/bitinn/node-fetch/issues/375#issuecomment-495953540 to fit the style of the other examples.

It's also worth noting that if you run it, the `Octocat.png` image comes back as 404 now, so we might want to update it, but I thought I should keep that out of scope here.